### PR TITLE
fix: getSubtypes() returned BasicEList causing exceptions

### DIFF
--- a/ac.soton.eventb.classdiagrams.feature/feature.properties
+++ b/ac.soton.eventb.classdiagrams.feature/feature.properties
@@ -25,6 +25,10 @@ entity-relationship data modelling and class lifting to Event-B models.\n\
 \n\
 Release history:\n\
 ------------------------------------------------------------------------\n\
+### 2.0.1 ### \n\
+ - (for Rodin 3.x.x)\n\
+  classdiagrams (2.0.1)\n\
+    - fix: SubtypeGroupImpl.getSubtypes() was returning a list that caused exceptions in EMF utility code\n\
 ### 2.0.0 ### \n\
  - (for Rodin 3.x.x)\n\
   classdiagrams (2.0.0)\n\

--- a/ac.soton.eventb.classdiagrams.feature/feature.xml
+++ b/ac.soton.eventb.classdiagrams.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.classdiagrams.feature"
       label="%featureName"
-      version="2.0.0.release"
+      version="2.0.1.qualifier"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.classdiagrams.branding"
       license-feature="org.rodinp.license"

--- a/ac.soton.eventb.classdiagrams.sdk/feature.properties
+++ b/ac.soton.eventb.classdiagrams.sdk/feature.properties
@@ -18,7 +18,7 @@ featureName=iUML-B Class Diagrams (for Rodin 3.x.x) SDK
 featureVendor=University of Southampton
 
 # "description" property - description of the feature
-description=\
+featureDescription=\
 This SDK feature provides the iUMLB Class Diagrams with its source code and unit tests. \n\
 It is intended for developers to use in a target platform while developing code that uses the \n\
 iUML-B Class Diagrams.\n\

--- a/ac.soton.eventb.classdiagrams.sdk/feature.properties
+++ b/ac.soton.eventb.classdiagrams.sdk/feature.properties
@@ -27,6 +27,9 @@ entity-relationship data modelling and class lifting to Event-B models.\n\
 \n\
 Release history:\n\
 ---------------\n\
+### 2.0.1 ###\n\
+- iUML-B Class Diagrams feature (2.0.1)\n\
+- iUML-B Class Diagrams source feature (2.0.1):Generated\n\
 ### 2.0.0 ###\n\
 - iUML-B Class Diagrams feature (2.0.0)\n\
 - iUML-B Class Diagrams source feature (2.0.0):Generated\n\

--- a/ac.soton.eventb.classdiagrams.sdk/feature.xml
+++ b/ac.soton.eventb.classdiagrams.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.classdiagrams.sdk"
       label="%featureName"
-      version="2.0.0.release"
+      version="2.0.1.qualifier"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.classdiagrams.branding"
       license-feature="org.rodinp.license"

--- a/ac.soton.eventb.classdiagrams/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.classdiagrams/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ac.soton.eventb.classdiagrams;singleton:=true
-Bundle-Version: 2.0.0.release
+Bundle-Version: 2.0.1.quantifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ac.soton.eventb.classdiagrams/src/ac/soton/eventb/classdiagrams/impl/SubtypeGroupImpl.java
+++ b/ac.soton.eventb.classdiagrams/src/ac/soton/eventb/classdiagrams/impl/SubtypeGroupImpl.java
@@ -13,11 +13,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.util.EcoreEList;
 import org.eventb.emf.core.EventBObject;
 import org.eventb.emf.core.impl.EventBNamedCommentedElementImpl;
 
@@ -149,7 +149,7 @@ public class SubtypeGroupImpl extends EventBNamedCommentedElementImpl implements
 	 * <!-- end-user-doc -->
 	 * @generated  NOT
 	 */
-	public EList<ac.soton.eventb.classdiagrams.Class> getSubtypes() {
+	public EList<Class> getSubtypes() {
 		List<ac.soton.eventb.classdiagrams.Class> subtypes = new  ArrayList<Class>();
 		EventBObject cd = this.getContaining(ClassdiagramsPackage.Literals.CLASSDIAGRAM);
 		for (EObject c : cd.getAllContained(ClassdiagramsPackage.Literals.CLASS, true)){
@@ -157,7 +157,7 @@ public class SubtypeGroupImpl extends EventBNamedCommentedElementImpl implements
 				subtypes.add((Class)c);
 			}
 		}
-		return new BasicEList.UnmodifiableEList<Class>(subtypes.size(),subtypes.toArray()) ;
+		return	new EcoreEList.UnmodifiableEList<Class>(this, ClassdiagramsPackage.Literals.SUBTYPE_GROUP__SUBTYPES, subtypes.size(), subtypes.toArray()) ;
 	}
 
 	/**


### PR DESCRIPTION
ac.soton.eventb.classdiagrams.impl.SubtypeGroupImpl.getSubtypes() was returning a
BasicElist.UnmodifiableEList  but this does not implement some interfaces assumed
by EMF util code. This caused exceptions. E.g. Delete command no longer worked for Class diagrams.
Now returns EcoreEList.UnmodifiableEList instead.